### PR TITLE
Add DSL terminology pass/fail coverage for identifier kinds

### DIFF
--- a/Tst/BlueDotBrigade.Analyzers.UnitTests/.Daten/Diagnostics/DslTerminologyAnalyzerTests/dsl-prefer-customer-block-cust.xml
+++ b/Tst/BlueDotBrigade.Analyzers.UnitTests/.Daten/Diagnostics/DslTerminologyAnalyzerTests/dsl-prefer-customer-block-cust.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dsl>
+  <term prefer="Customer" block="Cust" case="sensitive" />
+</dsl>

--- a/Tst/BlueDotBrigade.Analyzers.UnitTests/BlueDotBrigade.Analyzers.UnitTests.csproj
+++ b/Tst/BlueDotBrigade.Analyzers.UnitTests/BlueDotBrigade.Analyzers.UnitTests.csproj
@@ -13,10 +13,11 @@
 	  <Compile Include=".Daten\Diagnostics\DslTerminologyAnalyzerTests\code-violations.cs" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <Content Include=".Daten\Diagnostics\DslTerminologyAnalyzerTests\dsl-prefer-customer.xml" />
-	  <Content Include=".Daten\Diagnostics\DslTerminologyAnalyzerTests\dsl-simple.xml" />
-	</ItemGroup>
+        <ItemGroup>
+          <Content Include=".Daten\Diagnostics\DslTerminologyAnalyzerTests\dsl-prefer-customer.xml" />
+          <Content Include=".Daten\Diagnostics\DslTerminologyAnalyzerTests\dsl-prefer-customer-block-cust.xml" />
+          <Content Include=".Daten\Diagnostics\DslTerminologyAnalyzerTests\dsl-simple.xml" />
+        </ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\BlueDotBrigade.Analyzers\BlueDotBrigade.Analyzers.csproj" />

--- a/Tst/BlueDotBrigade.Analyzers.UnitTests/Diagnostics/DslTerminologyAnalyzerTests.cs
+++ b/Tst/BlueDotBrigade.Analyzers.UnitTests/Diagnostics/DslTerminologyAnalyzerTests.cs
@@ -7,13 +7,6 @@ namespace BlueDotBrigade.Analyzers.Diagnostics
     [TestClass]
     public class DslTerminologyAnalyzerTests
     {
-        private const string DslPreferCustomerBlockCust = """
-<?xml version="1.0" encoding="utf-8"?>
-<dsl>
-  <term prefer="Customer" block="Cust" case="sensitive" />
-</dsl>
-""";
-
         [TestMethod]
         public async Task NoDiagnostics_When_NoBlockedTerms()
         {
@@ -311,7 +304,9 @@ public class Example
                 TestCode = code,
             };
 
-            test.TestState.AdditionalFiles.Add(("src/TestProj/dsl.config.xml", DslPreferCustomerBlockCust));
+            var xml = new Daten().AsString("dsl-prefer-customer-block-cust.xml");
+
+            test.TestState.AdditionalFiles.Add(("src/TestProj/dsl.config.xml", xml));
             test.TestState.AdditionalFiles.Add(("/.editorconfig", "build_property.MSBuildProjectDirectory = src/TestProj"));
 
             return test;


### PR DESCRIPTION
## Summary
- add a reusable DSL definition that prefers "Customer" and blocks "Cust"
- cover pass scenarios for each identifier kind to ensure preferred terms are accepted
- add fail scenarios to verify blocked terms raise diagnostics for every symbol type

## Testing
- dotnet test *(fails: dotnet command not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690fae13a8f4832bb58525301a6880c3)