### PR TITLE
Add CLI tool for generating DSL sample configuration

### DIFF
--- a/Analyzers_v1.sln
+++ b/Analyzers_v1.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 18.0.11201.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlueDotBrigade.Analyzers", "Src\BlueDotBrigade.Analyzers\BlueDotBrigade.Analyzers.csproj", "{5CA8DE41-CF3B-4EB9-B6C3-4B8F7BBD3D6E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlueDotBrigade.Analyzers.Tool", "Src\BlueDotBrigade.Analyzers.Tool\BlueDotBrigade.Analyzers.Tool.csproj", "{DFAC78F0-2B83-4D2D-B249-51E5AD5C5E72}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlueDotBrigade.Analyzers.UnitTests", "Tst\BlueDotBrigade.Analyzers.UnitTests\BlueDotBrigade.Analyzers.UnitTests.csproj", "{FC79CD7C-4F1E-468D-ADF2-3D46DE057B1C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5B57D98F-4C5A-458D-ABA1-CDF0DD1998CB}"
@@ -25,8 +27,12 @@ Global
 		{5CA8DE41-CF3B-4EB9-B6C3-4B8F7BBD3D6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5CA8DE41-CF3B-4EB9-B6C3-4B8F7BBD3D6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5CA8DE41-CF3B-4EB9-B6C3-4B8F7BBD3D6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5CA8DE41-CF3B-4EB9-B6C3-4B8F7BBD3D6E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FC79CD7C-4F1E-468D-ADF2-3D46DE057B1C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {5CA8DE41-CF3B-4EB9-B6C3-4B8F7BBD3D6E}.Release|Any CPU.Build.0 = Release|Any CPU
+                {DFAC78F0-2B83-4D2D-B249-51E5AD5C5E72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {DFAC78F0-2B83-4D2D-B249-51E5AD5C5E72}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {DFAC78F0-2B83-4D2D-B249-51E5AD5C5E72}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {DFAC78F0-2B83-4D2D-B249-51E5AD5C5E72}.Release|Any CPU.Build.0 = Release|Any CPU
+                {FC79CD7C-4F1E-468D-ADF2-3D46DE057B1C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FC79CD7C-4F1E-468D-ADF2-3D46DE057B1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FC79CD7C-4F1E-468D-ADF2-3D46DE057B1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FC79CD7C-4F1E-468D-ADF2-3D46DE057B1C}.Release|Any CPU.Build.0 = Release|Any CPU

--- a/README.md
+++ b/README.md
@@ -78,6 +78,28 @@ If neither file exists, you’ll see warning `RC000` with a sample DSL, and no i
 
 ---
 
+## 🛠 Command-line helper
+
+The repository includes a small console utility (`BlueDotBrigade.Analyzers.Tool`) that can scaffold the sample DSL configuration
+file the analyzer expects.
+
+Common usage examples:
+
+```bash
+# Print the XML to the console
+dotnet run --project Src/BlueDotBrigade.Analyzers.Tool -- generate-dsl --stdout
+
+# Write the XML to the default dsl.config.xml in the current directory
+dotnet run --project Src/BlueDotBrigade.Analyzers.Tool -- generate-dsl
+
+# Overwrite or place the DSL file in a custom location
+dotnet run --project Src/BlueDotBrigade.Analyzers.Tool -- generate-dsl --output ./config/dsl.config.xml --force
+```
+
+Once packaged as a .NET tool you can invoke it as `bdb-analyzers generate-dsl` and pass the same options.
+
+---
+
 ## 🥪 Testing
 
 Unit tests use MSTest and `Microsoft.CodeAnalysis.Testing` harness.

--- a/Src/BlueDotBrigade.Analyzers.Tool/BlueDotBrigade.Analyzers.Tool.csproj
+++ b/Src/BlueDotBrigade.Analyzers.Tool/BlueDotBrigade.Analyzers.Tool.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\BlueDotBrigade.Analyzers\Dsl\DslDefaults.cs" Link="Dsl\DslDefaults.cs" />
+  </ItemGroup>
+</Project>

--- a/Src/BlueDotBrigade.Analyzers.Tool/Program.cs
+++ b/Src/BlueDotBrigade.Analyzers.Tool/Program.cs
@@ -1,0 +1,122 @@
+using BlueDotBrigade.Analyzers.Dsl;
+
+namespace BlueDotBrigade.Analyzers.Tool;
+
+internal static class Program
+{
+    private const string GenerateCommand = "generate-dsl";
+
+    private static int Main(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            PrintUsage();
+            return 1;
+        }
+
+        var command = args[0];
+        if (IsHelp(command))
+        {
+            PrintUsage();
+            return 0;
+        }
+
+        if (string.Equals(command, GenerateCommand, StringComparison.OrdinalIgnoreCase))
+        {
+            var commandArgs = args.Length > 1 ? args[1..] : Array.Empty<string>();
+            return ExecuteGenerateCommand(commandArgs);
+        }
+
+        Console.Error.WriteLine($"Unknown command '{command}'.");
+        PrintUsage();
+        return 1;
+    }
+
+    private static int ExecuteGenerateCommand(string[] args)
+    {
+        var outputPath = DslDefaults.DefaultDslFileName;
+        var writeToStdOut = false;
+        var overwrite = false;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var current = args[i];
+            if (IsHelp(current))
+            {
+                PrintGenerateUsage();
+                return 0;
+            }
+
+            switch (current)
+            {
+                case "--output":
+                    if (i + 1 >= args.Length)
+                    {
+                        Console.Error.WriteLine("--output option requires a value.");
+                        return 1;
+                    }
+
+                    outputPath = args[++i];
+                    break;
+                case "--stdout":
+                    writeToStdOut = true;
+                    break;
+                case "--force":
+                    overwrite = true;
+                    break;
+                default:
+                    Console.Error.WriteLine($"Unrecognized option '{current}'.");
+                    PrintGenerateUsage();
+                    return 1;
+            }
+        }
+
+        if (writeToStdOut)
+        {
+            Console.Out.WriteLine(DslDefaults.DefaultDslXml);
+            return 0;
+        }
+
+        var fullPath = Path.GetFullPath(outputPath);
+        var directory = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        if (!overwrite && File.Exists(fullPath))
+        {
+            Console.Error.WriteLine($"File '{fullPath}' already exists. Use --force to overwrite it or --stdout to print.");
+            return 1;
+        }
+
+        File.WriteAllText(fullPath, DslDefaults.DefaultDslXml);
+        Console.Out.WriteLine($"Sample DSL written to '{fullPath}'.");
+        return 0;
+    }
+
+    private static bool IsHelp(string value)
+        => string.Equals(value, "-h", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(value, "--help", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(value, "help", StringComparison.OrdinalIgnoreCase);
+
+    private static void PrintUsage()
+    {
+        Console.Out.WriteLine("Usage: bdb-analyzers <command> [options]");
+        Console.Out.WriteLine();
+        Console.Out.WriteLine("Commands:");
+        Console.Out.WriteLine($"  {GenerateCommand}    Generate the sample DSL file used by the analyzer.");
+        Console.Out.WriteLine();
+        Console.Out.WriteLine($"Run 'bdb-analyzers {GenerateCommand} --help' for command-specific options.");
+    }
+
+    private static void PrintGenerateUsage()
+    {
+        Console.Out.WriteLine($"Usage: bdb-analyzers {GenerateCommand} [--output <path>] [--stdout] [--force]");
+        Console.Out.WriteLine();
+        Console.Out.WriteLine("Options:");
+        Console.Out.WriteLine($"  --output <path>  Destination file path. Defaults to '{DslDefaults.DefaultDslFileName}'.");
+        Console.Out.WriteLine("  --stdout         Print the XML to standard output instead of writing a file.");
+        Console.Out.WriteLine("  --force          Overwrite the destination file if it already exists.");
+    }
+}

--- a/Src/BlueDotBrigade.Analyzers/Diagnostics/DslTerminologyAnalyzer.cs
+++ b/Src/BlueDotBrigade.Analyzers/Diagnostics/DslTerminologyAnalyzer.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 
+using BlueDotBrigade.Analyzers.Dsl;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -25,18 +27,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 public sealed class DslTerminologyAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "BDB001";
-    private const string DefaultDslFileName = "dsl.config.xml";
-
-    private static readonly string DefaultDslXml = """
-    <dsl>
-      <term prefer="Customer" block="Client" case="sensitive"/>
-      <term prefer="Customer" case="sensitive">
-        <alias block="Client"/>
-        <alias block="Cust"/>
-      </term>
-    </dsl>
-    """;
-
     private static readonly DiagnosticDescriptor Rule = new(
         id: DiagnosticId,
         title: "Blocked term in identifier",
@@ -96,7 +86,7 @@ public sealed class DslTerminologyAnalyzer : DiagnosticAnalyzer
             {
                 startCtx.RegisterCompilationEndAction(endCtx =>
                 {
-                    var diag = Diagnostic.Create(MissingConfigRule, Location.None, targetFileName, DefaultDslXml);
+                    var diag = Diagnostic.Create(MissingConfigRule, Location.None, targetFileName, DslDefaults.DefaultDslXml);
                     endCtx.ReportDiagnostic(diag);
                 });
             }
@@ -137,7 +127,7 @@ public sealed class DslTerminologyAnalyzer : DiagnosticAnalyzer
     {
         options.AnalyzerConfigOptionsProvider.GlobalOptions
             .TryGetValue("build_property.AnalyzerDslFileName", out var configuredName);
-        return string.IsNullOrWhiteSpace(configuredName) ? DefaultDslFileName : configuredName.Trim();
+        return string.IsNullOrWhiteSpace(configuredName) ? DslDefaults.DefaultDslFileName : configuredName.Trim();
     }
 
     private static string? GetProjectDirectory(AnalyzerOptions options)

--- a/Src/BlueDotBrigade.Analyzers/Dsl/DslDefaults.cs
+++ b/Src/BlueDotBrigade.Analyzers/Dsl/DslDefaults.cs
@@ -1,0 +1,20 @@
+namespace BlueDotBrigade.Analyzers.Dsl;
+
+/// <summary>
+/// Shared defaults for DSL configuration content that can be reused by analyzers
+/// and command-line tooling.
+/// </summary>
+public static class DslDefaults
+{
+    public const string DefaultDslFileName = "dsl.config.xml";
+
+    public const string DefaultDslXml = """
+<dsl>
+  <term prefer=\"Customer\" block=\"Client\" case=\"sensitive\"/>
+  <term prefer=\"Customer\" case=\"sensitive\">
+    <alias block=\"Client\"/>
+    <alias block=\"Cust\"/>
+  </term>
+</dsl>
+""";
+}


### PR DESCRIPTION
## Summary
- factor the DSL sample XML into a shared helper so it can be reused
- add a console project that exposes a `generate-dsl` command for emitting the sample file
- document the new utility and wire it into the solution

## Testing
- unable to run `dotnet build` (dotnet CLI not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690fcde1c82c832badc0febd878741e7)